### PR TITLE
Implement reservation management (EPIC 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@
 local.properties
 
 
+CLAUDE.MD
 /.claude
-CLAUDE.md

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,10 @@
             android:name=".view.MyEventsActivity"
             android:exported="false" />
 
+        <activity
+            android:name=".view.MyReservationsActivity"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
@@ -14,6 +14,7 @@ import com.example.ticketreservationapp.view.CreateEventActivity;
 import com.example.ticketreservationapp.view.EventListActivity;
 import com.example.ticketreservationapp.view.LoginActivity;
 import com.example.ticketreservationapp.view.MyEventsActivity;
+import com.example.ticketreservationapp.view.MyReservationsActivity;
 import com.google.android.material.button.MaterialButton;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -59,6 +60,9 @@ public class MainActivity extends AppCompatActivity {
 
         btnMyEvents.setOnClickListener(v ->
                 startActivity(new Intent(this, MyEventsActivity.class)));
+
+        findViewById(R.id.btn_my_reservations).setOnClickListener(v ->
+                startActivity(new Intent(this, MyReservationsActivity.class)));
 
         findViewById(R.id.btn_sign_out).setOnClickListener(v -> {
             FirebaseAuth.getInstance().signOut();

--- a/app/src/main/java/com/example/ticketreservationapp/model/Reservation.java
+++ b/app/src/main/java/com/example/ticketreservationapp/model/Reservation.java
@@ -1,0 +1,51 @@
+package com.example.ticketreservationapp.model;
+
+public class Reservation {
+    private String id;
+    private String userId;
+    private String eventId;
+    private String eventTitle;
+    private String eventDate;
+    private String eventLocation;
+    private int numberOfTickets;
+    private double totalPrice;
+    private long createdAt;
+    private String confirmationCode;
+
+    public Reservation() {}
+
+    public Reservation(String userId, String eventId, String eventTitle, String eventDate,
+                       String eventLocation, int numberOfTickets, double totalPrice,
+                       long createdAt, String confirmationCode) {
+        this.userId = userId;
+        this.eventId = eventId;
+        this.eventTitle = eventTitle;
+        this.eventDate = eventDate;
+        this.eventLocation = eventLocation;
+        this.numberOfTickets = numberOfTickets;
+        this.totalPrice = totalPrice;
+        this.createdAt = createdAt;
+        this.confirmationCode = confirmationCode;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+    public String getEventId() { return eventId; }
+    public void setEventId(String eventId) { this.eventId = eventId; }
+    public String getEventTitle() { return eventTitle; }
+    public void setEventTitle(String eventTitle) { this.eventTitle = eventTitle; }
+    public String getEventDate() { return eventDate; }
+    public void setEventDate(String eventDate) { this.eventDate = eventDate; }
+    public String getEventLocation() { return eventLocation; }
+    public void setEventLocation(String eventLocation) { this.eventLocation = eventLocation; }
+    public int getNumberOfTickets() { return numberOfTickets; }
+    public void setNumberOfTickets(int numberOfTickets) { this.numberOfTickets = numberOfTickets; }
+    public double getTotalPrice() { return totalPrice; }
+    public void setTotalPrice(double totalPrice) { this.totalPrice = totalPrice; }
+    public long getCreatedAt() { return createdAt; }
+    public void setCreatedAt(long createdAt) { this.createdAt = createdAt; }
+    public String getConfirmationCode() { return confirmationCode; }
+    public void setConfirmationCode(String confirmationCode) { this.confirmationCode = confirmationCode; }
+}

--- a/app/src/main/java/com/example/ticketreservationapp/repository/ReservationRepository.java
+++ b/app/src/main/java/com/example/ticketreservationapp/repository/ReservationRepository.java
@@ -1,0 +1,187 @@
+package com.example.ticketreservationapp.repository;
+
+import androidx.annotation.NonNull;
+
+import com.example.ticketreservationapp.model.Reservation;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+public class ReservationRepository {
+
+    public interface ReservationCallback {
+        void onSuccess(Reservation reservation);
+        void onError(String message);
+    }
+
+    public interface SimpleCallback {
+        void onSuccess();
+        void onError(String message);
+    }
+
+    public interface ReservationListCallback {
+        void onSuccess(List<Reservation> reservations);
+        void onError(String message);
+    }
+
+    private final FirebaseFirestore firestore;
+
+    public ReservationRepository() {
+        this.firestore = FirebaseFirestore.getInstance();
+    }
+
+    public ReservationRepository(FirebaseFirestore firestore) {
+        this.firestore = firestore;
+    }
+
+    /**
+     * Atomically reserves tickets: checks seat availability and creates a reservation.
+     */
+    public void reserveTicket(String userId, String eventId, int numberOfTickets,
+                              ReservationCallback callback) {
+        if (numberOfTickets <= 0) {
+            callback.onError("Number of tickets must be greater than zero");
+            return;
+        }
+        DocumentReference eventRef = firestore.collection("events").document(eventId);
+        DocumentReference reservationRef = firestore.collection("reservations").document();
+
+        firestore.runTransaction(transaction -> {
+            DocumentSnapshot eventSnap = transaction.get(eventRef);
+            if (!eventSnap.exists()) {
+                throw new IllegalStateException("Event no longer exists");
+            }
+            Long availableSeatsLong = eventSnap.getLong("availableSeats");
+            int availableSeats = availableSeatsLong == null ? 0 : availableSeatsLong.intValue();
+            if (availableSeats < numberOfTickets) {
+                throw new IllegalStateException("Not enough seats available");
+            }
+
+            String title = eventSnap.getString("title");
+            String date = eventSnap.getString("date");
+            String location = eventSnap.getString("location");
+            Double price = eventSnap.getDouble("price");
+            double unitPrice = price == null ? 0 : price;
+
+            Reservation reservation = new Reservation(
+                    userId, eventId,
+                    title == null ? "" : title,
+                    date == null ? "" : date,
+                    location == null ? "" : location,
+                    numberOfTickets,
+                    unitPrice * numberOfTickets,
+                    System.currentTimeMillis(),
+                    UUID.randomUUID().toString().substring(0, 8).toUpperCase());
+            reservation.setId(reservationRef.getId());
+
+            transaction.update(eventRef, "availableSeats", availableSeats - numberOfTickets);
+            transaction.set(reservationRef, reservation);
+            return reservation;
+        }).addOnSuccessListener(reservation -> {
+            sendConfirmation(reservation);
+            callback.onSuccess(reservation);
+        }).addOnFailureListener(e -> callback.onError(e.getMessage()));
+    }
+
+    /**
+     * Queues a confirmation message to be delivered by the Firebase "Trigger Email"
+     * and "Send SMS" extensions. Writing to these collections is enough — the
+     * extensions watch them and dispatch via SMTP / Twilio respectively.
+     */
+    private void sendConfirmation(Reservation reservation) {
+        com.google.firebase.auth.FirebaseUser user =
+                com.google.firebase.auth.FirebaseAuth.getInstance().getCurrentUser();
+        if (user == null) return;
+
+        String subject = "Reservation confirmed: " + reservation.getEventTitle();
+        String text = String.format(Locale.US,
+                "Your reservation is confirmed.%n%n" +
+                        "Event: %s%nDate: %s%nLocation: %s%n" +
+                        "Tickets: %d%nTotal: $%.2f%n%n" +
+                        "Confirmation code: %s",
+                reservation.getEventTitle(),
+                reservation.getEventDate(),
+                reservation.getEventLocation(),
+                reservation.getNumberOfTickets(),
+                reservation.getTotalPrice(),
+                reservation.getConfirmationCode());
+
+        // Email path — Firebase "Trigger Email" extension watches `mail/`.
+        String email = user.getEmail();
+        if (email != null && !email.isEmpty()) {
+            Map<String, Object> message = new HashMap<>();
+            message.put("subject", subject);
+            message.put("text", text);
+
+            Map<String, Object> mail = new HashMap<>();
+            mail.put("to", email);
+            mail.put("message", message);
+            mail.put("reservationId", reservation.getId());
+            firestore.collection("mail").add(mail);
+        }
+
+        // SMS path — Firebase "Send SMS" (Twilio) extension watches `messages/`.
+        String phone = user.getPhoneNumber();
+        if (phone != null && !phone.isEmpty()) {
+            Map<String, Object> sms = new HashMap<>();
+            sms.put("to", phone);
+            sms.put("body", text);
+            sms.put("reservationId", reservation.getId());
+            firestore.collection("messages").add(sms);
+        }
+    }
+
+    /**
+     * Cancels a reservation and restores seat availability atomically.
+     */
+    public void cancelReservation(@NonNull String reservationId, SimpleCallback callback) {
+        DocumentReference reservationRef = firestore.collection("reservations").document(reservationId);
+
+        firestore.runTransaction(transaction -> {
+            DocumentSnapshot reservationSnap = transaction.get(reservationRef);
+            if (!reservationSnap.exists()) {
+                throw new IllegalStateException("Reservation not found");
+            }
+            String eventId = reservationSnap.getString("eventId");
+            Long ticketsLong = reservationSnap.getLong("numberOfTickets");
+            int tickets = ticketsLong == null ? 0 : ticketsLong.intValue();
+
+            if (eventId != null) {
+                DocumentReference eventRef = firestore.collection("events").document(eventId);
+                DocumentSnapshot eventSnap = transaction.get(eventRef);
+                if (eventSnap.exists()) {
+                    Long availableSeatsLong = eventSnap.getLong("availableSeats");
+                    int availableSeats = availableSeatsLong == null ? 0 : availableSeatsLong.intValue();
+                    transaction.update(eventRef, "availableSeats", availableSeats + tickets);
+                }
+            }
+            transaction.delete(reservationRef);
+            return null;
+        }).addOnSuccessListener(aVoid -> callback.onSuccess())
+          .addOnFailureListener(e -> callback.onError(e.getMessage()));
+    }
+
+    public void getReservationsByUser(String userId, ReservationListCallback callback) {
+        firestore.collection("reservations")
+                .whereEqualTo("userId", userId)
+                .get()
+                .addOnSuccessListener(querySnapshot -> {
+                    List<Reservation> reservations = new ArrayList<>();
+                    for (QueryDocumentSnapshot doc : querySnapshot) {
+                        Reservation reservation = doc.toObject(Reservation.class);
+                        reservation.setId(doc.getId());
+                        reservations.add(reservation);
+                    }
+                    callback.onSuccess(reservations);
+                })
+                .addOnFailureListener(e -> callback.onError(e.getMessage()));
+    }
+}

--- a/app/src/main/java/com/example/ticketreservationapp/view/EventDetailActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/view/EventDetailActivity.java
@@ -2,7 +2,9 @@ package com.example.ticketreservationapp.view;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -12,7 +14,9 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.ticketreservationapp.R;
+import com.example.ticketreservationapp.model.Reservation;
 import com.example.ticketreservationapp.repository.EventRepository;
+import com.example.ticketreservationapp.repository.ReservationRepository;
 import com.google.android.material.button.MaterialButton;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -64,6 +68,7 @@ public class EventDetailActivity extends AppCompatActivity {
         TextView tvOrganizer = findViewById(R.id.tv_detail_organizer);
         MaterialButton btnEdit = findViewById(R.id.btn_edit_event);
         MaterialButton btnCancel = findViewById(R.id.btn_cancel_event);
+        MaterialButton btnReserve = findViewById(R.id.btn_reserve_ticket);
 
         tvTitle.setText(eventTitle);
         tvDate.setText(eventDate);
@@ -74,17 +79,95 @@ public class EventDetailActivity extends AppCompatActivity {
         tvPrice.setText(String.format(Locale.US, "$%.2f", eventPrice));
         tvSeats.setText(getString(R.string.seats_available, eventAvailableSeats, eventTotalSeats));
 
-        // Show edit/cancel buttons only if current user is the organizer
+        // Show edit/cancel buttons only if current user is the organizer; otherwise show Reserve.
         FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
-        if (currentUser != null && eventOrganizerId != null
-                && currentUser.getUid().equals(eventOrganizerId)) {
+        boolean isOrganizer = currentUser != null && eventOrganizerId != null
+                && currentUser.getUid().equals(eventOrganizerId);
+        if (isOrganizer) {
             btnEdit.setVisibility(View.VISIBLE);
             btnCancel.setVisibility(View.VISIBLE);
+        } else if (currentUser != null) {
+            btnReserve.setVisibility(View.VISIBLE);
         }
 
         btnEdit.setOnClickListener(v -> openEditEvent());
         btnCancel.setOnClickListener(v -> confirmCancelEvent());
+        btnReserve.setOnClickListener(v -> showReserveDialog());
         findViewById(R.id.btn_back).setOnClickListener(v -> finish());
+    }
+
+    private void showReserveDialog() {
+        if (eventAvailableSeats <= 0) {
+            Toast.makeText(this, R.string.error_no_seats, Toast.LENGTH_LONG).show();
+            return;
+        }
+        EditText input = new EditText(this);
+        input.setInputType(InputType.TYPE_CLASS_NUMBER);
+        input.setHint(R.string.hint_number_of_tickets);
+        int padding = (int) (16 * getResources().getDisplayMetrics().density);
+        input.setPadding(padding, padding, padding, padding);
+
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.reserve_dialog_title)
+                .setMessage(getString(R.string.reserve_dialog_message, eventAvailableSeats))
+                .setView(input)
+                .setPositiveButton(R.string.action_reserve, (dialog, which) -> {
+                    String text = input.getText().toString().trim();
+                    int qty;
+                    try {
+                        qty = Integer.parseInt(text);
+                    } catch (NumberFormatException e) {
+                        Toast.makeText(this, R.string.error_invalid_ticket_count, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+                    if (qty <= 0) {
+                        Toast.makeText(this, R.string.error_invalid_ticket_count, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+                    if (qty > eventAvailableSeats) {
+                        Toast.makeText(this, R.string.error_no_seats, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+                    submitReservation(qty);
+                })
+                .setNegativeButton(R.string.action_cancel, null)
+                .show();
+    }
+
+    private void submitReservation(int qty) {
+        FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+        if (currentUser == null) return;
+        new ReservationRepository().reserveTicket(currentUser.getUid(), eventId, qty,
+                new ReservationRepository.ReservationCallback() {
+                    @Override
+                    public void onSuccess(Reservation reservation) {
+                        eventAvailableSeats -= qty;
+                        TextView tvSeats = findViewById(R.id.tv_detail_seats);
+                        tvSeats.setText(getString(R.string.seats_available,
+                                eventAvailableSeats, eventTotalSeats));
+                        showConfirmation(reservation);
+                    }
+
+                    @Override
+                    public void onError(String message) {
+                        Toast.makeText(EventDetailActivity.this, message, Toast.LENGTH_LONG).show();
+                    }
+                });
+    }
+
+    private void showConfirmation(Reservation r) {
+        String message = getString(R.string.reservation_success_message,
+                r.getEventTitle(),
+                r.getNumberOfTickets(),
+                r.getTotalPrice(),
+                r.getEventDate(),
+                r.getEventLocation(),
+                r.getConfirmationCode());
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.reservation_success_title)
+                .setMessage(message)
+                .setPositiveButton(R.string.action_ok, null)
+                .show();
     }
 
     private void openEditEvent() {

--- a/app/src/main/java/com/example/ticketreservationapp/view/MyReservationsActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/view/MyReservationsActivity.java
@@ -1,0 +1,85 @@
+package com.example.ticketreservationapp.view;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ticketreservationapp.R;
+import com.example.ticketreservationapp.viewmodel.MyReservationsViewModel;
+import com.google.android.material.progressindicator.LinearProgressIndicator;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+
+public class MyReservationsActivity extends AppCompatActivity {
+
+    private MyReservationsViewModel viewModel;
+    private ReservationAdapter adapter;
+    private TextView tvNoResults;
+    private LinearProgressIndicator progressBar;
+    private String userId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_my_reservations);
+
+        viewModel = new ViewModelProvider(this).get(MyReservationsViewModel.class);
+
+        RecyclerView recyclerView = findViewById(R.id.rv_reservations);
+        tvNoResults = findViewById(R.id.tv_no_results);
+        progressBar = findViewById(R.id.progress_bar);
+
+        adapter = new ReservationAdapter(this::confirmCancel);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        recyclerView.setAdapter(adapter);
+
+        findViewById(R.id.btn_back).setOnClickListener(v -> finish());
+
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user != null) {
+            userId = user.getUid();
+            observeViewModel();
+            viewModel.loadReservations(userId);
+        }
+    }
+
+    private void confirmCancel(com.example.ticketreservationapp.model.Reservation reservation) {
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.cancel_reservation_dialog_title)
+                .setMessage(getString(R.string.cancel_reservation_dialog_message, reservation.getEventTitle()))
+                .setPositiveButton(R.string.action_yes, (dialog, which) ->
+                        viewModel.cancelReservation(reservation.getId()))
+                .setNegativeButton(R.string.action_no, null)
+                .show();
+    }
+
+    private void observeViewModel() {
+        viewModel.getReservations().observe(this, reservations -> {
+            adapter.setReservations(reservations);
+            tvNoResults.setVisibility(reservations.isEmpty() ? View.VISIBLE : View.GONE);
+        });
+
+        viewModel.getLoading().observe(this, isLoading ->
+                progressBar.setVisibility(Boolean.TRUE.equals(isLoading) ? View.VISIBLE : View.GONE));
+
+        viewModel.getErrorMessage().observe(this, msg -> {
+            if (msg != null && !msg.isEmpty()) {
+                Toast.makeText(this, msg, Toast.LENGTH_LONG).show();
+            }
+        });
+
+        viewModel.getCancelSuccess().observe(this, success -> {
+            if (Boolean.TRUE.equals(success)) {
+                Toast.makeText(this, R.string.reservation_cancelled_success, Toast.LENGTH_SHORT).show();
+                viewModel.loadReservations(userId);
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/example/ticketreservationapp/view/ReservationAdapter.java
+++ b/app/src/main/java/com/example/ticketreservationapp/view/ReservationAdapter.java
@@ -1,0 +1,81 @@
+package com.example.ticketreservationapp.view;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ticketreservationapp.R;
+import com.example.ticketreservationapp.model.Reservation;
+import com.google.android.material.button.MaterialButton;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class ReservationAdapter extends RecyclerView.Adapter<ReservationAdapter.VH> {
+
+    public interface OnCancelClick {
+        void onCancel(Reservation reservation);
+    }
+
+    private List<Reservation> reservations = new ArrayList<>();
+    private final OnCancelClick onCancelClick;
+
+    public ReservationAdapter(OnCancelClick onCancelClick) {
+        this.onCancelClick = onCancelClick;
+    }
+
+    public void setReservations(List<Reservation> reservations) {
+        this.reservations = reservations == null ? new ArrayList<>() : reservations;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_reservation, parent, false);
+        return new VH(v);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull VH holder, int position) {
+        Reservation r = reservations.get(position);
+        holder.title.setText(r.getEventTitle());
+        holder.date.setText(r.getEventDate());
+        holder.location.setText(r.getEventLocation());
+        holder.tickets.setText(holder.itemView.getContext()
+                .getString(R.string.tickets_count, r.getNumberOfTickets()));
+        holder.total.setText(String.format(Locale.US, "$%.2f", r.getTotalPrice()));
+        holder.code.setText(holder.itemView.getContext()
+                .getString(R.string.confirmation_code_label, r.getConfirmationCode()));
+        holder.btnCancel.setOnClickListener(v -> {
+            if (onCancelClick != null) onCancelClick.onCancel(r);
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return reservations.size();
+    }
+
+    static class VH extends RecyclerView.ViewHolder {
+        TextView title, date, location, tickets, total, code;
+        MaterialButton btnCancel;
+
+        VH(@NonNull View itemView) {
+            super(itemView);
+            title = itemView.findViewById(R.id.tv_res_title);
+            date = itemView.findViewById(R.id.tv_res_date);
+            location = itemView.findViewById(R.id.tv_res_location);
+            tickets = itemView.findViewById(R.id.tv_res_tickets);
+            total = itemView.findViewById(R.id.tv_res_total);
+            code = itemView.findViewById(R.id.tv_res_code);
+            btnCancel = itemView.findViewById(R.id.btn_cancel_reservation);
+        }
+    }
+}

--- a/app/src/main/java/com/example/ticketreservationapp/viewmodel/MyReservationsViewModel.java
+++ b/app/src/main/java/com/example/ticketreservationapp/viewmodel/MyReservationsViewModel.java
@@ -1,0 +1,67 @@
+package com.example.ticketreservationapp.viewmodel;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import com.example.ticketreservationapp.model.Reservation;
+import com.example.ticketreservationapp.repository.ReservationRepository;
+
+import java.util.List;
+
+public class MyReservationsViewModel extends ViewModel {
+
+    private final ReservationRepository repository;
+
+    private final MutableLiveData<List<Reservation>> reservations = new MutableLiveData<>();
+    private final MutableLiveData<String> errorMessage = new MutableLiveData<>();
+    private final MutableLiveData<Boolean> loading = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> cancelSuccess = new MutableLiveData<>();
+
+    public MyReservationsViewModel() {
+        this.repository = new ReservationRepository();
+    }
+
+    public MyReservationsViewModel(ReservationRepository repository) {
+        this.repository = repository;
+    }
+
+    public LiveData<List<Reservation>> getReservations() { return reservations; }
+    public LiveData<String> getErrorMessage() { return errorMessage; }
+    public LiveData<Boolean> getLoading() { return loading; }
+    public LiveData<Boolean> getCancelSuccess() { return cancelSuccess; }
+
+    public void loadReservations(String userId) {
+        loading.setValue(true);
+        repository.getReservationsByUser(userId, new ReservationRepository.ReservationListCallback() {
+            @Override
+            public void onSuccess(List<Reservation> list) {
+                reservations.setValue(list);
+                loading.setValue(false);
+            }
+
+            @Override
+            public void onError(String message) {
+                errorMessage.setValue(message);
+                loading.setValue(false);
+            }
+        });
+    }
+
+    public void cancelReservation(String reservationId) {
+        loading.setValue(true);
+        repository.cancelReservation(reservationId, new ReservationRepository.SimpleCallback() {
+            @Override
+            public void onSuccess() {
+                cancelSuccess.setValue(true);
+                loading.setValue(false);
+            }
+
+            @Override
+            public void onError(String message) {
+                errorMessage.setValue(message);
+                loading.setValue(false);
+            }
+        });
+    }
+}

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -198,6 +198,16 @@
                     android:textColor="@color/text_secondary"
                     android:lineSpacingMultiplier="1.3" />
 
+                <!-- Reserve ticket button (customer view) -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_reserve_ticket"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:minHeight="48dp"
+                    android:text="@string/btn_reserve_ticket"
+                    android:visibility="gone" />
+
                 <!-- Edit button (organizer only) -->
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/btn_edit_event"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -32,6 +32,15 @@
         android:text="@string/btn_browse_events" />
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_my_reservations"
+        style="@style/Widget.Material3.Button.TonalButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:minHeight="48dp"
+        android:text="@string/btn_my_reservations" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_create_event"
         style="@style/Widget.Material3.Button.TonalButton"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_my_reservations.xml
+++ b/app/src/main/res/layout/activity_my_reservations.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_surface"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/brand_primary"
+        android:orientation="vertical"
+        android:padding="20dp"
+        android:paddingTop="36dp">
+
+        <ImageButton
+            android:id="@+id/btn_back"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_marginBottom="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/btn_back"
+            android:src="@drawable/ic_arrow_back"
+            app:tint="@android:color/white" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/my_reservations_title"
+            android:textAppearance="?attr/textAppearanceHeadlineMedium"
+            android:textColor="@android:color/white"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/my_reservations_subtitle"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="@color/primary_container" />
+
+    </LinearLayout>
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/tv_no_results"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="32dp"
+        android:text="@string/no_reservations_found"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textColor="@color/text_secondary"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_reservations"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingTop="12dp"
+        android:paddingBottom="16dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_reservation.xml
+++ b/app/src/main/res/layout/item_reservation.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
+    android:layout_marginTop="6dp"
+    android:layout_marginBottom="6dp"
+    app:cardBackgroundColor="@color/bg_card"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="3dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tv_res_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tv_res_date"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="@color/text_secondary" />
+
+        <TextView
+            android:id="@+id/tv_res_location"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="@color/text_secondary" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="12dp"
+            android:background="@color/border_color" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tv_res_tickets"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="@color/text_primary" />
+
+            <TextView
+                android:id="@+id/tv_res_total"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceTitleMedium"
+                android:textColor="@color/brand_primary"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tv_res_code"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:textAppearance="?attr/textAppearanceLabelMedium"
+            android:textColor="@color/brand_accent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_cancel_reservation"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:minHeight="44dp"
+            android:text="@string/btn_cancel_reservation"
+            android:textColor="@color/color_error"
+            app:strokeColor="@color/color_error" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,29 @@
     <string name="cancel_event_dialog_title">Cancel Event</string>
     <string name="cancel_event_dialog_message">Are you sure you want to cancel \"%1$s\"? This action cannot be undone.</string>
 
+    <!-- Reservation -->
+    <string name="btn_reserve_ticket">Reserve Ticket</string>
+    <string name="btn_my_reservations">My Reservations</string>
+    <string name="reserve_dialog_title">Reserve Tickets</string>
+    <string name="reserve_dialog_message">How many tickets would you like to reserve? (Available: %1$d)</string>
+    <string name="hint_number_of_tickets">Number of tickets</string>
+    <string name="action_reserve">Reserve</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="reservation_success_title">Reservation Confirmed</string>
+    <string name="reservation_success_message">Your reservation for \"%1$s\" is confirmed.\n\nTickets: %2$d\nTotal: $%3$.2f\nDate: %4$s\nLocation: %5$s\n\nConfirmation code: %6$s\n\nA confirmation has been sent to your email.</string>
+    <string name="reservation_cancelled_success">Reservation cancelled successfully.</string>
+    <string name="cancel_reservation_dialog_title">Cancel Reservation</string>
+    <string name="cancel_reservation_dialog_message">Are you sure you want to cancel your reservation for \"%1$s\"?</string>
+    <string name="my_reservations_title">My Reservations</string>
+    <string name="my_reservations_subtitle">View and manage your bookings</string>
+    <string name="no_reservations_found">You have no reservations yet.</string>
+    <string name="btn_cancel_reservation">Cancel Reservation</string>
+    <string name="tickets_count">Tickets: %1$d</string>
+    <string name="confirmation_code_label">Code: %1$s</string>
+    <string name="error_invalid_ticket_count">Please enter a valid number of tickets</string>
+    <string name="error_no_seats">Not enough seats available</string>
+    <string name="action_ok">OK</string>
+
     <!-- Category array for filter dropdown -->
     <string-array name="event_categories">
         <item>All Categories</item>

--- a/app/src/test/java/com/example/ticketreservationapp/MyReservationsViewModelTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/MyReservationsViewModelTest.java
@@ -1,0 +1,165 @@
+package com.example.ticketreservationapp;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
+
+import com.example.ticketreservationapp.model.Reservation;
+import com.example.ticketreservationapp.repository.ReservationRepository;
+import com.example.ticketreservationapp.viewmodel.MyReservationsViewModel;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class MyReservationsViewModelTest {
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    /** Hand-rolled fake — sidesteps Mockito/ByteBuddy JDK compatibility issues. */
+    private static class FakeReservationRepository extends ReservationRepository {
+        String lastUserId;
+        String lastCancelledId;
+        int loadCalls = 0;
+        int cancelCalls = 0;
+
+        // Programmable behaviour
+        boolean shouldSucceed = true;
+        List<Reservation> resultList = Collections.emptyList();
+        String errorMessage = "boom";
+        boolean invokeCallback = true;
+
+        FakeReservationRepository() {
+            // Pass null Firestore so we don't touch Firebase from JVM tests.
+            super(null);
+        }
+
+        @Override
+        public void getReservationsByUser(String userId, ReservationListCallback callback) {
+            loadCalls++;
+            lastUserId = userId;
+            if (!invokeCallback) return;
+            if (shouldSucceed) callback.onSuccess(resultList);
+            else callback.onError(errorMessage);
+        }
+
+        @Override
+        public void cancelReservation(String reservationId, SimpleCallback callback) {
+            cancelCalls++;
+            lastCancelledId = reservationId;
+            if (!invokeCallback) return;
+            if (shouldSucceed) callback.onSuccess();
+            else callback.onError(errorMessage);
+        }
+    }
+
+    private FakeReservationRepository fakeRepo;
+    private MyReservationsViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        fakeRepo = new FakeReservationRepository();
+        viewModel = new MyReservationsViewModel(fakeRepo);
+    }
+
+    private <T> List<T> collectValues(LiveData<T> liveData) {
+        List<T> values = new ArrayList<>();
+        liveData.observeForever(values::add);
+        return values;
+    }
+
+    // loadReservations ─────────────────────────────────────────────────────
+
+    @Test
+    public void loadReservations_callsRepositoryWithUserId() {
+        fakeRepo.invokeCallback = false;
+        viewModel.loadReservations("user1");
+        assertEquals(1, fakeRepo.loadCalls);
+        assertEquals("user1", fakeRepo.lastUserId);
+    }
+
+    @Test
+    public void loadReservations_setsLoadingTrueBeforeCallback() {
+        fakeRepo.invokeCallback = false;
+        List<Boolean> loadingStates = collectValues(viewModel.getLoading());
+        viewModel.loadReservations("user1");
+        assertTrue(loadingStates.contains(true));
+    }
+
+    @Test
+    public void loadReservations_success_postsReservationsAndStopsLoading() {
+        Reservation r = new Reservation(
+                "user1", "event1", "Show", "2026-05-01",
+                "Montreal", 2, 100.0, 1L, "CODE1");
+        fakeRepo.resultList = Arrays.asList(r);
+
+        viewModel.loadReservations("user1");
+
+        assertEquals(fakeRepo.resultList, viewModel.getReservations().getValue());
+        assertEquals(Boolean.FALSE, viewModel.getLoading().getValue());
+    }
+
+    @Test
+    public void loadReservations_emptySuccess_postsEmptyList() {
+        fakeRepo.resultList = Collections.emptyList();
+        viewModel.loadReservations("user1");
+        assertNotNull(viewModel.getReservations().getValue());
+        assertTrue(viewModel.getReservations().getValue().isEmpty());
+    }
+
+    @Test
+    public void loadReservations_error_postsErrorAndStopsLoading() {
+        fakeRepo.shouldSucceed = false;
+        fakeRepo.errorMessage = "network down";
+
+        List<String> errors = collectValues(viewModel.getErrorMessage());
+        viewModel.loadReservations("user1");
+
+        assertTrue(errors.contains("network down"));
+        assertEquals(Boolean.FALSE, viewModel.getLoading().getValue());
+    }
+
+    // cancelReservation ────────────────────────────────────────────────────
+
+    @Test
+    public void cancelReservation_callsRepositoryWithReservationId() {
+        fakeRepo.invokeCallback = false;
+        viewModel.cancelReservation("res1");
+        assertEquals(1, fakeRepo.cancelCalls);
+        assertEquals("res1", fakeRepo.lastCancelledId);
+    }
+
+    @Test
+    public void cancelReservation_setsLoadingTrueBeforeCallback() {
+        fakeRepo.invokeCallback = false;
+        List<Boolean> loadingStates = collectValues(viewModel.getLoading());
+        viewModel.cancelReservation("res1");
+        assertTrue(loadingStates.contains(true));
+    }
+
+    @Test
+    public void cancelReservation_success_postsCancelSuccessTrue() {
+        viewModel.cancelReservation("res1");
+        assertEquals(Boolean.TRUE, viewModel.getCancelSuccess().getValue());
+        assertEquals(Boolean.FALSE, viewModel.getLoading().getValue());
+    }
+
+    @Test
+    public void cancelReservation_error_postsErrorMessageAndStopsLoading() {
+        fakeRepo.shouldSucceed = false;
+        fakeRepo.errorMessage = "Reservation not found";
+
+        List<String> errors = collectValues(viewModel.getErrorMessage());
+        viewModel.cancelReservation("res1");
+
+        assertTrue(errors.contains("Reservation not found"));
+        assertEquals(Boolean.FALSE, viewModel.getLoading().getValue());
+    }
+}

--- a/app/src/test/java/com/example/ticketreservationapp/ReservationTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/ReservationTest.java
@@ -1,0 +1,63 @@
+package com.example.ticketreservationapp;
+
+import com.example.ticketreservationapp.model.Reservation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ReservationTest {
+
+    @Test
+    public void defaultConstructor_createsEmptyInstance() {
+        Reservation r = new Reservation();
+        assertNull(r.getId());
+        assertNull(r.getUserId());
+        assertNull(r.getEventId());
+        assertEquals(0, r.getNumberOfTickets());
+        assertEquals(0.0, r.getTotalPrice(), 0.0001);
+    }
+
+    @Test
+    public void parameterizedConstructor_setsAllFields() {
+        Reservation r = new Reservation(
+                "user1", "event1", "Concert", "2026-05-01",
+                "Montreal", 3, 150.0, 1234567890L, "ABC123");
+
+        assertEquals("user1", r.getUserId());
+        assertEquals("event1", r.getEventId());
+        assertEquals("Concert", r.getEventTitle());
+        assertEquals("2026-05-01", r.getEventDate());
+        assertEquals("Montreal", r.getEventLocation());
+        assertEquals(3, r.getNumberOfTickets());
+        assertEquals(150.0, r.getTotalPrice(), 0.0001);
+        assertEquals(1234567890L, r.getCreatedAt());
+        assertEquals("ABC123", r.getConfirmationCode());
+    }
+
+    @Test
+    public void setters_updateFields() {
+        Reservation r = new Reservation();
+        r.setId("res1");
+        r.setUserId("u1");
+        r.setEventId("e1");
+        r.setEventTitle("Movie");
+        r.setEventDate("2026-06-15");
+        r.setEventLocation("Laval");
+        r.setNumberOfTickets(2);
+        r.setTotalPrice(40.0);
+        r.setCreatedAt(999L);
+        r.setConfirmationCode("XYZ789");
+
+        assertEquals("res1", r.getId());
+        assertEquals("u1", r.getUserId());
+        assertEquals("e1", r.getEventId());
+        assertEquals("Movie", r.getEventTitle());
+        assertEquals("2026-06-15", r.getEventDate());
+        assertEquals("Laval", r.getEventLocation());
+        assertEquals(2, r.getNumberOfTickets());
+        assertEquals(40.0, r.getTotalPrice(), 0.0001);
+        assertEquals(999L, r.getCreatedAt());
+        assertEquals("XYZ789", r.getConfirmationCode());
+    }
+}


### PR DESCRIPTION
## Description
Implements all user stories under EPIC 3: Reservation Management.

### What's included
- **US 3.1 – Reserve Ticket**: Customers can open an event and tap **Reserve Ticket** to choose a quantity. A Firestore transaction verifies seat availability, decrements `availableSeats`, and persists a reservation atomically so concurrent bookings cannot oversell an event.
- **US 3.2 – Cancel Reservation**: New **My Reservations** screen lists the signed-in user's bookings. Cancelling a reservation runs a transaction that deletes it and restores the event's seat count, with a confirmation toast on success.
- **US 3.3 – Receive Confirmation**: Successful reservations show a confirmation dialog containing event title, date, location, ticket count, total price, and a unique confirmation code. Each reservation persists this code for later reference.

### Architecture
Follows the existing MVVM layout:
- `model/Reservation.java` – Firestore POJO
- `repository/ReservationRepository.java` – transactional reserve/cancel + user query
- `viewmodel/MyReservationsViewModel.java` – LiveData for reservations list
- `view/MyReservationsActivity.java` + `ReservationAdapter.java` – list & cancel UI
- `EventDetailActivity` – Reserve button + quantity dialog + confirmation dialog
- `MainActivity` – new **My Reservations** entry point